### PR TITLE
Feat 17/streamlit for eda

### DIFF
--- a/src/EDA_Streamlit.py
+++ b/src/EDA_Streamlit.py
@@ -40,6 +40,15 @@ def load_json(dataset_path):
 
     return train_data, test_data
 
+# bbox 좌표 계산
+def calculate_bbox(bbox):
+    # bbox 좌표 계산
+    x_min, y_min, width, height = bbox
+    x_max = x_min + width
+    y_max = y_min + height
+
+    return x_min, y_min, x_max, y_max
+
 # bbox 출력
 def draw_bbox(image, annotations):
     # 이미지에 대한 draw 객체 생성
@@ -57,9 +66,7 @@ def draw_bbox(image, annotations):
         annotation_table[category_name] += 1
 
         # bbox 좌표 계산
-        x_min, y_min, width, height = bbox
-        x_max = x_min + width
-        y_max = y_min + height
+        x_min, y_min, x_max, y_max = calculate_bbox(bbox)
         
         # bbox 그리기
         draw.rectangle([(x_min, y_min), (x_max, y_max)], outline=category_colors[category_id][0], width=3)
@@ -151,14 +158,21 @@ def apply_augmentation(image, annotations, aug_method):
     return aug_image, new_annotations
 
 
-def bbox_heatmap(annotations, image_size=(1024, 1024)):
+def bbox_heatmap(all_annotations, selected_category, image_size=(1024, 1024)):
     heatmap = np.zeros(image_size, dtype=np.float32)
     fig, ax = plt.subplots()
+    
+    # 선택된 카테고리에 맞는 annotation 필터링
+    if selected_category != "All":
+        # 선택된 카테고리 ID가 리스트이므로 [0]을 통해 ID 값만 추출
+        category_id = [key for key, value in category_colors.items() if value[1] == selected_category][0]
+        # 그때의 카테고리 ID에 해당하는 annotation만 추출
+        annotations = [ann for ann in all_annotations if ann['category_id'] == category_id]
+    else:
+        annotations = all_annotations
 
     for ann in annotations:
-        x_min, y_min, width, height = map(int, ann['bbox'])
-        x_max = x_min + width
-        y_max = y_min + height
+        x_min, y_min, x_max, y_max = map(int, calculate_bbox(ann['bbox']))
 
         # Increment heatmap values for the region covered by the bbox
         heatmap[y_min:y_max, x_min:x_max] += 1
@@ -185,14 +199,54 @@ def count_by_category(annotations, sort=False):
 
     return fig
 
+# bbox 넓이 계산
+def calculate_bbox_area(annotation):
+    bbox_area = {i : [] for i in range(10)}
+
+    for ann in annotation:
+        bbox = ann['bbox']
+        category_id = ann['category_id']
+        area = round(bbox[2] * bbox[3], 1)
+        bbox_area[category_id].append(area)
+        
+    return bbox_area
+
+# bbox 넓이에 따라 선택
+def select_bbox_area(bbox_area, min_area, max_area):
+    for key, value in bbox_area.items():
+        bbox_area[key] = [area for area in value if min_area <= area <= max_area]
+
+    return bbox_area
+
+# bbox area 시각화 (히스토그램)
+def bbox_area_viz(bbox_area, selected_category):
+    # 선택된 카테고리에 맞는 bbox 영역 필터링
+    if selected_category != "All":
+        category_id = [key for key, value in category_colors.items() if value[1] == selected_category][0]
+        bbox_areas = bbox_area[category_id]
+    else:
+        # 모든 카테고리 선택 시, 모든 영역을 병합
+        bbox_areas = [area for areas in bbox_area.values() for area in areas]
+
+    # 그래프 생성
+    fig, ax = plt.subplots()
+    sns.histplot(bbox_areas, bins=20, ax=ax)
+    ax.set_title(f"BBox Area Distribution for {selected_category}")
+    ax.set_xlabel("Area")
+    ax.set_ylabel("Count")
+    
+    return fig
+
 def main(opt):
     # st.set_page_config(layout="wide")
 
-    menu = st.sidebar.radio("Menu", ["Train 데이터 시각화 확인하기", "Train 데이터 EDA"])
+    menu = st.sidebar.radio("Menu", ["Train 데이터 EDA", "Train 데이터 시각화 확인하기"])
 
     # json 파일 로드
     dataset_path = opt.dataset_path
     train_data, test_data = load_json(dataset_path)
+
+    all_annotations = [ann for ann in train_data['annotations']]
 
     # json 파일에서 이미지 파일명, id를 추출
     image_files, image_ids = zip(*[(img['file_name'], img['id']) for img in train_data['images']])
@@ -296,23 +350,31 @@ def main(opt):
         # 카테고리 별 heatmap 시각화를 위한 radio button
         selected_category = heatmap_category.radio(
             "바운딩 박스를 확인할 카테고리를 선택하세요",
-            options=[category_colors[i][1] for i in range(10)] + ["All"]
+            options=[category_colors[i][1] for i in range(10)] + ["All"],
+            key="heatmap_category_selection" 
         )
 
-        # 선택된 카테고리에 맞는 annotation 필터링
-        if selected_category != "All":
-            # 선택된 카테고리 ID가 리스트이므로 [0]을 통해 ID 값만 추출
-            category_id = [key for key, value in category_colors.items() if value[1] == selected_category][0]
-            # 그때의 카테고리 ID에 해당하는 annotation만 추출
-            annotations = [ann for ann in train_data['annotations'] if ann['category_id'] == category_id]
-        else:
-            annotations = [ann for ann in train_data['annotations']]
-
         # 모든 annotation 데이터를 기반으로 히트맵 생성
-        heatmap = bbox_heatmap(annotations)
+        heatmap = bbox_heatmap(all_annotations, selected_category)
 
         # 히트맵 출력
         heatmap_viz.pyplot(heatmap)
+
+        st.subheader("카테고리 별 bbox 크기 분포")
+        bbox_area = calculate_bbox_area(all_annotations)
+        
+        col_category_bbox_area, col_bbox_area = st.columns([1, 4])
+
+        selected_category_for_bbox_area = col_category_bbox_area.radio(
+            "바운딩 박스를 확인할 카테고리를 선택하세요",
+            options=[category_colors[i][1] for i in range(10)] + ["All"],
+            key="bbox_area_category_selection"
+        )
+
+        bbox_area_slider = st.slider("확인할 bbox의 넓이를 선택하세요", 0, 1024*1024, (250000, 680000))
+        selected_bbox_area = select_bbox_area(bbox_area, bbox_area_slider[0], bbox_area_slider[1])
+        bbox_area_histogram= bbox_area_viz(selected_bbox_area, selected_category_for_bbox_area)
+        col_bbox_area.pyplot(bbox_area_histogram)
 
 if __name__ == '__main__':
     opt = parse_args()


### PR DESCRIPTION
## 🔴 Related Issue Number
- Resolved: #17

## 💡 Work Description
- Train EDA을 위한 bbox 시각화를 진행했습니다. 먼저 카테고리 별로 데이터 갯수를 확인할 수 있게 했고, sort 버튼을 통해 정렬된 그래프를 볼 수 있게 했습니다.
 또한, bbox 위치를 1024 * 1024 heatmap에서 시각화하고 카테고리 별로 확인할 수 있게 시각화했습니다. 
 마지막으로 slider를 통해 bbox의 min, max 크기를 지정하면 해당 크기에 관련된 bbox의 크기를 시각화 및 카테고리 별로도 bbox의 크기를 시각화했습니다.

## 📷 Screenshot
|기능|스크린샷|
|:--:|:--:|
|카테고리 별 데이터 갯수 시각화|<img src = "https://github.com/user-attachments/assets/4bdb0cfb-6291-4b10-956e-66867c7db79b" width ="1000">
|카테고리 별 Bbox 위치 시각화 (heatmap)|<img src = "https://github.com/user-attachments/assets/b22fbb6f-987a-4a48-9b11-bca059cf3da5" width ="1000">|
|카테고리 별, 크기 별 Bbox 크기 그래프 시각화|<img src = "https://github.com/user-attachments/assets/e98e36ed-2adb-41a0-bceb-2b091629d8a0" width ="1000">|

## 📖 Reference
- seaborn heatmap 참고:[https://seaborn.pydata.org/generated/seaborn.heatmap.html]
- st.pyplot 참고 :  [https://docs.streamlit.io/develop/api-reference/charts/st.pyplot]
- 강의자료 : AI 개발 기초 03. Streamlit을 활용한 웹 프로토타입 구현하기

## 👥 To Reviewers
- 방금 윤서님이 지적해주신 버그도 추후에 개선해보겠습니다.
  
## ✅ Checklists
- [x] 깃 컨벤션 및 팀 규칙에 맞게 작성되었나요?
- [x] 불필요한 코드 및 주석이나 디버깅 코드는 제거되었나요?
- [x] 기능이 동작하는지 테스트했나요?