### PR TITLE
:sparkle: add wandb tracking (Features #12)

### DIFF
--- a/mmdetection_faster_rcnn_train.ipynb
+++ b/mmdetection_faster_rcnn_train.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,15 +14,12 @@
     "from mmdet.apis import train_detector\n",
     "from mmdet.datasets import (build_dataloader, build_dataset,\n",
     "                            replace_ImageToTensor)\n",
-    "from mmdet.utils import get_device\n",
-    "\n",
-    "import mlflow\n",
-    "from mmcv.runner import MlflowLoggerHook"
+    "from mmdet.utils import get_device"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,8 +34,13 @@
     "# dataset config 수정\n",
     "cfg.data.train.classes = classes\n",
     "cfg.data.train.img_prefix = root\n",
-    "cfg.data.train.ann_file = root + 'train.json' # train json 정보\n",
+    "cfg.data.train.ann_file = root + 'train_split_random.json' # train json 정보\n",
     "cfg.data.train.pipeline[2]['img_scale'] = (512,512) # Resize\n",
+    "\n",
+    "cfg.data.val.classes = classes\n",
+    "cfg.data.val.img_prefix = root\n",
+    "cfg.data.val.ann_file = root + 'val_split_random.json' # test json 정보\n",
+    "cfg.data.val.pipeline[1]['img_scale'] = (512,512) # Resize\n",
     "\n",
     "cfg.data.test.classes = classes\n",
     "cfg.data.test.img_prefix = root\n",
@@ -56,25 +58,30 @@
     "cfg.fp16 = dict(loss_scale=512.0) # Mixed Precision training\n",
     "\n",
     "cfg.optimizer_config.grad_clip = dict(max_norm=35, norm_type=2)\n",
-    "cfg.checkpoint_config = dict(max_keep_ckpts=3, interval=1)\n",
+    "cfg.checkpoint_config = dict(max_keep_ckpts=3, interval=6)\n",
     "cfg.device = get_device()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# MLflow 서버 URI 설정\n",
-    "mlflow.set_tracking_uri(\"http://10.28.224.171:30280/\")\n",
+    "# wandb init arguments : 필요 없으면 모두 None으로 해도됨 \n",
+    "run_name = 'faster_rcnn_r50_fpn_1x_coco'\n",
+    "tags = ['baseline', 'faster_rcnn'] # 원하는 태그 설정\n",
+    "notes = 'First experiments with wandb' # 해당 run에 대한 설명\n",
     "\n",
-    "# MLflow 로거 추가\n",
-    "cfg.log_config.hooks.append(\n",
-    "    dict(type='MlflowLoggerHook',\n",
-    "         exp_name='mmdetection_baseline',\n",
-    "         log_model=True)\n",
-    ")"
+    "# wandb hooks 추가 \n",
+    "cfg.log_config.hooks = [\n",
+    "    dict(type='TextLoggerHook'),\n",
+    "    dict(type='MMDetWandbHook',\n",
+    "         init_kwargs={'project': 'MMDetection', 'entity': 'buan99-personal', 'name': run_name, 'tags': tags, 'notes': notes},\n",
+    "         interval=10,\n",
+    "         log_checkpoint=True,\n",
+    "         log_checkpoint_metadata=True,\n",
+    "         num_eval_images=0)]\n"
    ]
   },
   {
@@ -117,7 +124,7 @@
     "meta = dict() # Mixed Precision training\n",
     "\n",
     "# 모델 학습\n",
-    "train_detector(model, datasets[0], cfg, distributed=False, validate=False, meta=meta)"
+    "train_detector(model, datasets[0], cfg, distributed=False, validate=True, meta=meta)"
    ]
   }
  ],


### PR DESCRIPTION
## 🔴 Related Issue Number
- Resolved: #12 

## 💡 Work Description
- mmdetection을 사용한 학습 코드에 wandb ui에서 확인할 수 있도록 experiments tracking 기능 추가 

## 📷 Screenshot
<!-- 구현한 기능을 보여주는 스크린샷을 넣어주세요. "" 안에 이미지 url을 넣어주세요. 없으면 지워주세요. -->
|기능|스크린샷|
|:--:|:--:|
|wandb UI에서 실험 추적 가능|<img src = "https://github.com/user-attachments/assets/7ec4078d-631e-4d91-882e-ecb4338c2250" width ="250">


## 👥 To Reviewers
wandb 코드 및 사용법 설명 -> 노션 확인해주시면 됩니다~
1. pip install wandb 필수 
2. 처음 실행 시 해당 링크 [https://wandb.ai/authorize](https://wandb.ai/authorize)에서 api key 복사하여 입력창 나오면 입력 -> 처음 한 번만 하면 돼요. 이후에는 안나와요. 
3. 학습 실행하면 해당 프로젝트를 확인할 수 있는 링크 나옵니다. 링크 들어가셔서 실험 추적 확인하시면 돼요.

## 🚧 Uncompleted Tasks
  - [ ] wandb resitry의 모델 파일 불러와서 모델 평가하기. 
  
## ✅ Checklists
- [x] 깃 컨벤션 및 팀 규칙에 맞게 작성되었나요?
- [x] 불필요한 코드 및 주석이나 디버깅 코드는 제거되었나요?
- [x] 기능이 동작하는지 테스트했나요?